### PR TITLE
fix(APP-654): unhide veCTX Guardians from Cryptex DAO

### DIFF
--- a/dao-overrides.json
+++ b/dao-overrides.json
@@ -19,16 +19,5 @@
                 "comment": "XMAQUINA needed velockers but not gauges."
             }
         ]
-    },
-    "ethereum-mainnet-0xf204245b0B05E9A0780761E326552A569c1D6ceb": {
-        "daoName": "Cryptex",
-        "comment": "Hide governance bodies that should not be exposed in the members, proposals, and settings flows.",
-        "pluginsToHide": [
-            {
-                "address": "0x453D0792f28aa694e533a7fFbe06F4e11e2b7885",
-                "name": "veCTX Guardians",
-                "comment": "Exclude this body from governance navigation and member selection."
-            }
-        ]
     }
 }


### PR DESCRIPTION
Temporarily remove veCTX Guardians from pluginsToHide so SPP proposals referencing this body (e.g. CIPX-3) stop crashing on the proposal page.

Will be re-added once the corresponding code fix in app (useDaoPlugins visibility filter) is released.