### PR TITLE
Revert "fix(APP-654): unhide veCTX Guardians from Cryptex DAO (#30)"

### DIFF
--- a/dao-overrides.json
+++ b/dao-overrides.json
@@ -20,13 +20,13 @@
             }
         ]
     },
-    "avax-mainnet-0x0738688cB4F27B0c66938Ce36C79969A1CD0fD3B": {
-        "daoName": "Test",
-        "comment": "Test bug APP-654. This can be reverted the next time this file is updated.",
+    "ethereum-mainnet-0xf204245b0B05E9A0780761E326552A569c1D6ceb": {
+        "daoName": "Cryptex",
+        "comment": "Hide governance bodies that should not be exposed in the members, proposals, and settings flows.",
         "pluginsToHide": [
             {
-                "address": "0x3Ca30641522Bb06A7cAd20f28570F290E4392c5D",
-                "name": "Token voting",
+                "address": "0x453D0792f28aa694e533a7fFbe06F4e11e2b7885",
+                "name": "veCTX Guardians",
                 "comment": "Exclude this body from governance navigation and member selection."
             }
         ]


### PR DESCRIPTION
This reverts commit 67b5926bdaee0f0b1aabd948e4328d1ec9183a4b.

https://linear.app/aragon/issue/APP-655/revert-app-cms-body-visibility-change-after-fix-goes-live