### PR TITLE
Add missing feature flags from app code

### DIFF
--- a/feature-flags.json
+++ b/feature-flags.json
@@ -26,5 +26,61 @@
     "development": false,
     "staging": false,
     "production": true
+  },
+  "governanceDesigner": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": true,
+    "production": true
+  },
+  "osxUpdates": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": true,
+    "production": true
+  },
+  "useMocks": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": false,
+    "production": false
+  },
+  "enableAllPlugins": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": false,
+    "production": false
+  },
+  "existingProposalCreationCondition": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": false,
+    "production": false
+  },
+  "aragonProfiles": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": true,
+    "production": true
+  },
+  "supportChat": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": false,
+    "production": false
+  },
+  "permissionsPage": {
+    "local": true,
+    "preview": true,
+    "development": true,
+    "staging": false,
+    "production": false
   }
 }


### PR DESCRIPTION
Adds the 8 feature flags defined in `apps/app` (`src/shared/featureFlags/featureFlags.constants.ts`) that were missing from `feature-flags.json`. Per-environment values mirror the code definitions (`environments[env] ?? defaultValue`). The 4 existing flags are left untouched.

New flags:

| Flag | local | preview | development | staging | production |
| --- | --- | --- | --- | --- | --- |
| governanceDesigner | ✅ | ✅ | ✅ | ✅ | ✅ |
| osxUpdates | ✅ | ✅ | ✅ | ✅ | ✅ |
| useMocks | ✅ | ✅ | ✅ | ❌ | ❌ |
| enableAllPlugins | ✅ | ✅ | ✅ | ❌ | ❌ |
| existingProposalCreationCondition | ✅ | ✅ | ✅ | ❌ | ❌ |
| aragonProfiles | ✅ | ✅ | ✅ | ✅ | ✅ |
| supportChat | ✅ | ✅ | ✅ | ❌ | ❌ |
| permissionsPage | ✅ | ✅ | ✅ | ❌ | ❌ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)